### PR TITLE
Add main readme with module overviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,162 @@
-Placeholder
+# Workshop: LLM and RAG
+
+## Setting Up
+
+To set up the `application-secrets.properties` in the root, add the following values:
+
+```
+spring.ai.azure.openai.endpoint=${AZURE_OPENAI_ENDPOINT}
+spring.ai.azure.openai.api-key=${AZURE_OPENAI_API_KEY}
+```
+
+## Modules Overview
+
+### Module 1: Connecting to the LLM
+**Objective:**
+Learn how to connect to ChatGPT using an API key within a Spring Boot application.
+
+**Contents:**
+- Setting up Spring AI dependencies.
+- Configuring API keys.
+- Writing a simple CommandLineRunner to send and receive a single message from ChatGPT.
+
+**Exercises:**
+- Implement a CommandLineRunner that sends a prompt to ChatGPT and prints the response.
+- Handle exceptions and errors from the API.
+
+### Module 2: Prompt Engineering - Tips & Tricks
+**Objective:**
+Understand the fundamentals of prompt engineering, e.g. one-shot, multishot, chain of thought.
+
+**Contents:**
+- Best practices for crafting prompts.
+- Using system prompts effectively.
+
+**Exercises:**
+- Craft prompt to achieve better responses, play around with tricky situations.
+- Experiment with system prompts to guide the LLM's behavior.
+
+### Module 3: Introduction to Spring AI
+**Objective:**
+Explore the features of Spring AI and how it integrates with Spring Boot applications.
+
+**Contents:**
+- Overview of Spring AI capabilities.
+- Configuring Spring AI in a Spring Boot project.
+- Dependency injection with Spring AI components.
+
+**Exercises:**
+- Set up a basic Spring AI application.
+- Inject and use Spring AI beans in services and controllers.
+
+### Module 4: Using Tools and Services
+**Objective:**
+Learn how to extend the LLM's capabilities by integrating custom tools and services.
+
+**Contents:**
+- Creating custom functions that the LLM can invoke.
+- Understanding how Spring AI handles tool integration.
+
+**Exercises:**
+- Implement a method as a tool that retrieves a password.
+- Implement a method as a tool that overrides the password.
+- Configure the LLM to use this tool when generating responses.
+
+### Module 5: Context Enrichment with Text Files
+**Objective:**
+Understand context enrichment by reading and incorporating text file contents into prompts.
+
+**Contents:**
+- Reading files in Spring Boot applications.
+- Enriching prompts with external data.
+- Managing context size limitations.
+
+**Exercises:**
+- Password Retrieval from File:
+  - Store a password in a text file.
+  - Modify the tool from Module 4 to read from the file.
+- Information Retrieval:
+  - Read larger files containing more information.
+  - Summarize or extract relevant data for the prompt.
+
+### Module 6: Introduction to Retrieval Augmented Generation (RAG)
+**Objective:**
+Explore RAG concepts and understand when to apply them.
+
+**Contents:**
+- Challenges with large context sizes.
+- Overview of RAG and its benefits.
+- Introduction to chunking and vector databases.
+
+**Exercises:**
+- Limit context size to 1000 tokens and observe the impact.
+- Discuss the differences between traditional search (e.g., Elasticsearch) and vector databases.
+
+### Module 7: Working with Text Embeddings
+**Objective:**
+Learn about text embeddings and how to use them for similarity searches.
+
+**Contents:**
+- Explanation of embeddings and vector spaces.
+- Performing arithmetic with embeddings (e.g., king - queen + woman = man).
+- Integrating vector databases into Spring Boot applications.
+
+**Exercises:**
+- Embedding Arithmetic:
+  - Use embeddings to perform analogy tasks.
+  - Visualize embeddings in a vector space.
+- Vector Similarity Search:
+  - Index documents using embeddings.
+  - Retrieve relevant documents based on query similarity.
+- Data Chunking:
+  - Implement chunking of large texts.
+  - Store and retrieve chunks using embeddings.
+- Manual Vector Retrieval:
+  - Manually fetch vectors to understand relevance scoring.
+  - Observe issues with irrelevant data retrieval.
+
+### Module 8: Advanced Configurations
+**Objective:**
+Explore various configuration options to fine-tune the LLM interactions.
+
+**Contents:**
+- Adjusting model parameters (temperature, max tokens, etc.).
+- Handling rate limits and API quotas.
+- Logging and monitoring LLM interactions.
+
+**Exercises:**
+- Experiment with different configuration settings.
+- Implement logging to audit prompts and responses.
+
+### Module 9: Integrating DALLE-3
+**Objective:**
+Learn how to generate images using DALLE-3 and integrate it into your application.
+
+**Contents:**
+- Overview of DALLE-3 capabilities.
+- Configuring image generation in Spring AI.
+- Using system prompts to guide image creation.
+
+**Exercises:**
+- Generate images for your Pokémon, recipe, attire, or monster.
+- Customize prompts to influence the style and content of the images.
+
+### Module 10: Prompt Injection and Security
+**Objective:**
+Understand the risks of prompt injection and how to mitigate them.
+
+**Contents:**
+- Explanation of prompt injection attacks.
+- Best practices for securing LLM applications.
+- Testing prompts for vulnerabilities.
+
+**Exercises:**
+- Prompt Injection Simulation:
+  - Craft inputs that could lead to prompt injection.
+  - Observe how the LLM responds and identify weaknesses.
+- Mitigation Strategies:
+  - Implement input validation and sanitization.
+  - Use guardrails or prompt templates to enforce boundaries.
+- Prompt Testing:
+  - Develop tests to ensure prompts are secure.
+  - Automate prompt testing as part of the CI/CD pipeline.

--- a/ex-1-connect-to-llm/README.md
+++ b/ex-1-connect-to-llm/README.md
@@ -1,0 +1,13 @@
+# Module 1: Connecting to the LLM
+
+## Objective
+Learn how to connect to ChatGPT using an API key within a Spring Boot application.
+
+## Contents
+- Setting up Spring AI dependencies.
+- Configuring API keys.
+- Writing a simple CommandLineRunner to send and receive a single message from ChatGPT.
+
+## Exercises
+1. Implement a CommandLineRunner that sends a prompt to ChatGPT and prints the response.
+2. Handle exceptions and errors from the API.

--- a/ex-10-prompt-injection-and-security/README.md
+++ b/ex-10-prompt-injection-and-security/README.md
@@ -1,0 +1,20 @@
+# Module 10: Prompt Injection and Security
+
+## Objective
+Understand the risks of prompt injection and how to mitigate them.
+
+## Contents
+- Explanation of prompt injection attacks.
+- Best practices for securing LLM applications.
+- Testing prompts for vulnerabilities.
+
+## Exercises
+1. **Prompt Injection Simulation:**
+   - Craft inputs that could lead to prompt injection.
+   - Observe how the LLM responds and identify weaknesses.
+2. **Mitigation Strategies:**
+   - Implement input validation and sanitization.
+   - Use guardrails or prompt templates to enforce boundaries.
+3. **Prompt Testing:**
+   - Develop tests to ensure prompts are secure.
+   - Automate prompt testing as part of the CI/CD pipeline.

--- a/ex-2-prompt-engineering/README.md
+++ b/ex-2-prompt-engineering/README.md
@@ -1,0 +1,12 @@
+# Module 2: Prompt Engineering - Tips & Tricks
+
+## Objective
+Understand the fundamentals of prompt engineering, e.g. one-shot, multishot, chain of thought.
+
+## Contents
+- Best practices for crafting prompts.
+- Using system prompts effectively.
+
+## Exercises
+1. Craft prompt to achieve better responses, play around with tricky situations.
+2. Experiment with system prompts to guide the LLM's behavior.

--- a/ex-3-spring-ai-intro/README.md
+++ b/ex-3-spring-ai-intro/README.md
@@ -1,0 +1,14 @@
+# Module 3: Introduction to Spring AI
+
+## Objective
+Explore the features of Spring AI and how it integrates with Spring Boot applications.
+
+## Contents
+- Overview of Spring AI capabilities.
+- Configuring Spring AI in a Spring Boot project.
+- Dependency injection with Spring AI components.
+
+## Exercises
+1. Set up a basic Spring AI application.
+2. Inject and use Spring AI beans in services and controllers.
+3. Provide a ChatMemory bean and use it in a PromptChatMemoryAdvisor.

--- a/ex-4-using-tools/README.md
+++ b/ex-4-using-tools/README.md
@@ -1,0 +1,13 @@
+# Module 4: Using Tools and Services
+
+## Objective
+Learn how to extend the LLM's capabilities by integrating custom tools and services.
+
+## Contents
+- Creating custom functions that the LLM can invoke.
+- Understanding how Spring AI handles tool integration.
+
+## Exercises
+1. Implement a method as a tool that retrieves a password.
+2. Implement a method as a tool that overrides the password.
+3. Configure the LLM to use this tool when generating responses.

--- a/ex-5-context-enrichment/README.md
+++ b/ex-5-context-enrichment/README.md
@@ -1,0 +1,15 @@
+# Module 5: Context Enrichment with Text Files
+
+## Objective
+Understand context enrichment by reading and incorporating text file contents into prompts.
+
+## Contents
+- Reading files in Spring Boot applications.
+- Enriching prompts with external data.
+- Managing context size limitations.
+
+## Exercises
+1. Enrich prompts with the **current date** and **user name**.
+2. Information Retrieval:
+   - Enrich the prompt with contents from a single file.
+   - Limit context size to 500 tokens and observe the impact.

--- a/ex-6-introduction-to-rag/README.md
+++ b/ex-6-introduction-to-rag/README.md
@@ -1,0 +1,13 @@
+# Module 6: Introduction to Retrieval Augmented Generation (RAG)
+
+## Objective
+Explore RAG concepts and understand when to apply them.
+
+## Contents
+- Challenges with large context sizes.
+- Overview of RAG and its benefits.
+- Introduction to chunking and vector databases.
+
+## Exercises
+1. Discuss the differences between traditional search (e.g., Elasticsearch) and vector databases.
+2. Use Spring AI's QuestionAnswerAdvisor and a Vectorstore to retrieve relevant information.

--- a/ex-7-working-with-embeddings/README.md
+++ b/ex-7-working-with-embeddings/README.md
@@ -1,0 +1,23 @@
+# Module 7: Working with Text Embeddings
+
+## Objective
+Learn about text embeddings and how to use them for similarity searches.
+
+## Contents
+- Explanation of embeddings and vector spaces.
+- Performing arithmetic with embeddings (e.g., king - queen + woman = man).
+- Integrating vector databases into Spring Boot applications.
+
+## Exercises
+1. **Embedding Arithmetic:**
+   - Use embeddings to perform analogy tasks.
+   - Visualize embeddings in a vector space.
+2. **Vector Similarity Search:**
+   - Index documents using embeddings.
+   - Retrieve relevant documents based on query similarity.
+3. **Data Chunking:**
+   - Implement chunking of large texts.
+   - Store and retrieve chunks using embeddings.
+4. **Manual Vector Retrieval:**
+   - Manually fetch vectors to understand relevance scoring.
+   - Observe issues with irrelevant data retrieval.

--- a/ex-8-advanced-configurations/README.md
+++ b/ex-8-advanced-configurations/README.md
@@ -1,0 +1,13 @@
+# Module 8: Advanced Configurations
+
+## Objective
+Explore various configuration options to fine-tune the LLM interactions.
+
+## Contents
+- Adjusting model parameters (temperature, max tokens, etc.).
+- Handling rate limits and API quotas.
+- Logging and monitoring LLM interactions.
+
+## Exercises
+1. Experiment with different configuration settings.
+2. Implement logging to audit prompts and responses.

--- a/ex-9-integrating-dalle-3/README.md
+++ b/ex-9-integrating-dalle-3/README.md
@@ -1,0 +1,13 @@
+# Module 9: Integrating DALLE-3
+
+## Objective
+Learn how to generate images using DALLE-3 and integrate it into your application.
+
+## Contents
+- Overview of DALLE-3 capabilities.
+- Configuring image generation in Spring AI.
+- Using system prompts to guide image creation.
+
+## Exercises
+1. Generate images for your Pokémon, recipe, attire, or monster.
+2. Customize prompts to influence the style and content of the images.


### PR DESCRIPTION
Add a main README file and separate module READMEs for the workshop.

* **Main README:**
  - Add high-level overview of the workshop modules.
  - Add instructions on setting up `application-secrets.properties` with required values.

* **Module 1: Connecting to the LLM:**
  - Add objectives, contents, and exercises.

* **Module 2: Prompt Engineering - Tips & Tricks:**
  - Add objectives, contents, and exercises.

* **Module 3: Introduction to Spring AI:**
  - Add objectives, contents, and exercises.

* **Module 4: Using Tools and Services:**
  - Add objectives, contents, and exercises.

* **Module 5: Context Enrichment with Text Files:**
  - Add objectives, contents, and exercises.

* **Module 6: Introduction to Retrieval Augmented Generation (RAG):**
  - Add objectives, contents, and exercises.

* **Module 7: Working with Text Embeddings:**
  - Add objectives, contents, and exercises.

* **Module 8: Advanced Configurations:**
  - Add objectives, contents, and exercises.

* **Module 9: Integrating DALLE-3:**
  - Add objectives, contents, and exercises.

* **Module 10: Prompt Injection and Security:**
  - Add objectives, contents, and exercises.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/VinkVdB/workshop-llm-and-rag?shareId=551a987e-242b-4cea-99dc-ec69f1ece807).